### PR TITLE
fix: Lernplan-Themenname abgeschnitten (Fixes #18)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2025,3 +2025,20 @@ FEATURE UPGRADE: Tiefere Erklärungen + Abi-Screenshots nebendran
     width: 100%;
   }
 }
+
+
+/* ══ FIX #18: Lernplan-Themenname abgeschnitten ══ */
+/* Verhindert, dass lange Themennamen (z.B. "Elektrodynamik & Elektromagnetismus")
+   aus dem Container herauslaufen. Stattdessen werden sie mit ... abgekürzt. */
+.lernplan-topic {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+  display: block;
+}
+
+.plan-day-topics .lernplan-topic {
+  font-size: 0.78rem;
+  line-height: 1.3;
+}


### PR DESCRIPTION
## Beschreibung

Fix für Issue #18: Der Themenname "Elektrodynamik & Elektromagnetismus" läuft im 7-Tage-Lernplan-Modal über den verfügbaren Platz der Tageskarte hinaus, ohne Ellipsis oder Zeilenumbruch.

## Lösung

CSS-Klasse `.lernplan-topic` erhält:
- `overflow: hidden` – verhindert Overflow
- `text-overflow: ellipsis` – zeigt `...` wenn Text zu lang
- `white-space: nowrap` – verhindert Zeilenumbruch
- `max-width: 100%` – begrenzt auf Container-Breite

## Art der Änderung
- [x] Bug fix

## Closes
Closes #18